### PR TITLE
Update package.json with npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "webpack.config.js",
   "scripts": {
     "build": "NODE_ENV=production webpack --progress",
-    "dev": "webpack --watch --progress & nodemon index.js",
+    "dev": "npm-run-all --parallel server client",
     "server": "nodemon index.js",
     "client": "webpack --watch --progress",
     "linter": "eslint src",
@@ -45,6 +45,7 @@
     "husky": "^0.14.3",
     "jest": "^21.2.1",
     "nodemon": "^1.17.2",
+    "npm-run-all": "^4.1.3",
     "webpack": "^4.0.0",
     "webpack-bundle-analyzer": "^2.9.1",
     "webpack-cli": "^2.0.9",
@@ -73,5 +74,5 @@
     "setupTestFrameworkScriptFile": "<rootDir>/test-config/test-setup.js"
   },
   "author": "",
-  "license": "ISC"
+  "license": "MIT"
 }


### PR DESCRIPTION
In order to concurrently run the webpack watcher and nodemon the npm-run-all package is introduced to the npm run dev command.

Also updated the license to reflect what the package is actually licensed under

Fixes #1 